### PR TITLE
Updates config command message - hummingbot/hummingbot#6196

### DIFF
--- a/hbotrc/msgs.py
+++ b/hbotrc/msgs.py
@@ -57,6 +57,7 @@ class ConfigCommandMessage(RPCMessage):
 
     class Response(RPCMessage.Response):
         changes: Optional[List[Tuple[str, Any]]] = []
+        config: Optional[Dict[str, Any]] = {}
         status: Optional[int] = BROKER_STATUS_CODE.SUCCESS
         msg: Optional[str] = ''
 


### PR DESCRIPTION
Sync with https://github.com/hummingbot/hummingbot/pull/6196.

Adds a `config` property in response that includes client and strategy configuration parameters returned by the bot.