### PR TITLE
Updates commlib version - hummingbot/hbot-remote-client-py#2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-commlib-py = "0.8.0"
+commlib-py = "0.10.6"
 
 
 [build-system]

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ universal = 1
 packages = find:
 zip_safe = False
 install_requires =
-    commlib-py==0.10.0
+    commlib-py==0.10.6
 
 [flake8]
 exclude = docs


### PR DESCRIPTION
Updates commlib-py package version to `0.10.6`.

Resolves https://github.com/hummingbot/hbot-remote-client-py/issues/2.